### PR TITLE
[Auth-1] implement data by JPA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/si/authserver/core/authorization/JpaOAuth2AuthorizationService.java
+++ b/src/main/java/com/si/authserver/core/authorization/JpaOAuth2AuthorizationService.java
@@ -1,0 +1,297 @@
+package com.si.authserver.core.authorization;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.si.authserver.data.CustomAuthorization;
+import com.si.authserver.infra.mysql.AuthorizationRepository;
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2DeviceCode;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.OAuth2Token;
+import org.springframework.security.oauth2.core.OAuth2UserCode;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationCode;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+// TODO : Setter를 쓰지 않고 생성자를 통해 주입받도록 변경 필요
+@Component
+public class JpaOAuth2AuthorizationService implements OAuth2AuthorizationService {
+    private final AuthorizationRepository authorizationRepository;
+    private final RegisteredClientRepository registeredClientRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JpaOAuth2AuthorizationService(AuthorizationRepository authorizationRepository, RegisteredClientRepository registeredClientRepository) {
+        Assert.notNull(authorizationRepository, "authorizationRepository cannot be null");
+        Assert.notNull(registeredClientRepository, "registeredClientRepository cannot be null");
+        this.authorizationRepository = authorizationRepository;
+        this.registeredClientRepository = registeredClientRepository;
+
+        ClassLoader classLoader = JpaOAuth2AuthorizationService.class.getClassLoader();
+        List<Module> securityModules = SecurityJackson2Modules.getModules(classLoader);
+        this.objectMapper.registerModules(securityModules);
+        this.objectMapper.registerModule(new OAuth2AuthorizationServerJackson2Module());
+    }
+
+    @Override
+    public void save(OAuth2Authorization authorization) {
+        Assert.notNull(authorization, "authorization cannot be null");
+        this.authorizationRepository.save(toEntity(authorization));
+    }
+
+    @Override
+    public void remove(OAuth2Authorization authorization) {
+        Assert.notNull(authorization, "authorization cannot be null");
+        this.authorizationRepository.deleteById(authorization.getId());
+    }
+
+    @Override
+    public OAuth2Authorization findById(String id) {
+        Assert.hasText(id, "id cannot be empty");
+        return this.authorizationRepository.findById(id).map(this::toObject).orElse(null);
+    }
+
+    @Override
+    public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
+        Assert.hasText(token, "token cannot be empty");
+
+        Optional<CustomAuthorization> result;
+        if (tokenType == null) {
+            result = this.authorizationRepository.findByStateOrAuthorizationCodeValueOrAccessTokenValueOrRefreshTokenValueOrOidcIdTokenValueOrUserCodeValueOrDeviceCodeValue(token);
+        } else if (OAuth2ParameterNames.STATE.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByState(token);
+        } else if (OAuth2ParameterNames.CODE.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByAuthorizationCodeValue(token);
+        } else if (OAuth2ParameterNames.ACCESS_TOKEN.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByAccessTokenValue(token);
+        } else if (OAuth2ParameterNames.REFRESH_TOKEN.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByRefreshTokenValue(token);
+        } else if (OidcParameterNames.ID_TOKEN.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByOidcIdTokenValue(token);
+        } else if (OAuth2ParameterNames.USER_CODE.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByUserCodeValue(token);
+        } else if (OAuth2ParameterNames.DEVICE_CODE.equals(tokenType.getValue())) {
+            result = this.authorizationRepository.findByDeviceCodeValue(token);
+        } else {
+            result = Optional.empty();
+        }
+
+        return result.map(this::toObject).orElse(null);
+    }
+
+    private OAuth2Authorization toObject(CustomAuthorization entity) {
+        RegisteredClient registeredClient = this.registeredClientRepository.findById(entity.getRegisteredClientId());
+        if (registeredClient == null) {
+            throw new DataRetrievalFailureException(
+                    "The RegisteredClient with id '" + entity.getRegisteredClientId() + "' was not found in the RegisteredClientRepository.");
+        }
+
+        OAuth2Authorization.Builder builder = OAuth2Authorization.withRegisteredClient(registeredClient)
+                .id(entity.getId())
+                .principalName(entity.getPrincipalName())
+                .authorizationGrantType(resolveAuthorizationGrantType(entity.getAuthorizationGrantType()))
+                .authorizedScopes(StringUtils.commaDelimitedListToSet(entity.getAuthorizedScopes()))
+                .attributes(attributes -> attributes.putAll(parseMap(entity.getAttributes())));
+        if (entity.getState() != null) {
+            builder.attribute(OAuth2ParameterNames.STATE, entity.getState());
+        }
+
+        if (entity.getAuthorizationCodeValue() != null) {
+            OAuth2AuthorizationCode authorizationCode = new OAuth2AuthorizationCode(
+                    entity.getAuthorizationCodeValue(),
+                    entity.getAuthorizationCodeIssuedAt(),
+                    entity.getAuthorizationCodeExpiresAt());
+            builder.token(authorizationCode, metadata -> metadata.putAll(parseMap(entity.getAuthorizationCodeMetadata())));
+        }
+
+        if (entity.getAccessTokenValue() != null) {
+            OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                    OAuth2AccessToken.TokenType.BEARER,
+                    entity.getAccessTokenValue(),
+                    entity.getAccessTokenIssuedAt(),
+                    entity.getAccessTokenExpiresAt(),
+                    StringUtils.commaDelimitedListToSet(entity.getAccessTokenScopes()));
+            builder.token(accessToken, metadata -> metadata.putAll(parseMap(entity.getAccessTokenMetadata())));
+        }
+
+        if (entity.getRefreshTokenValue() != null) {
+            OAuth2RefreshToken refreshToken = new OAuth2RefreshToken(
+                    entity.getRefreshTokenValue(),
+                    entity.getRefreshTokenIssuedAt(),
+                    entity.getRefreshTokenExpiresAt());
+            builder.token(refreshToken, metadata -> metadata.putAll(parseMap(entity.getRefreshTokenMetadata())));
+        }
+
+        if (entity.getOidcIdTokenValue() != null) {
+            OidcIdToken idToken = new OidcIdToken(
+                    entity.getOidcIdTokenValue(),
+                    entity.getOidcIdTokenIssuedAt(),
+                    entity.getOidcIdTokenExpiresAt(),
+                    parseMap(entity.getOidcIdTokenClaims()));
+            builder.token(idToken, metadata -> metadata.putAll(parseMap(entity.getOidcIdTokenMetadata())));
+        }
+
+        if (entity.getUserCodeValue() != null) {
+            OAuth2UserCode userCode = new OAuth2UserCode(
+                    entity.getUserCodeValue(),
+                    entity.getUserCodeIssuedAt(),
+                    entity.getUserCodeExpiresAt());
+            builder.token(userCode, metadata -> metadata.putAll(parseMap(entity.getUserCodeMetadata())));
+        }
+
+        if (entity.getDeviceCodeValue() != null) {
+            OAuth2DeviceCode deviceCode = new OAuth2DeviceCode(
+                    entity.getDeviceCodeValue(),
+                    entity.getDeviceCodeIssuedAt(),
+                    entity.getDeviceCodeExpiresAt());
+            builder.token(deviceCode, metadata -> metadata.putAll(parseMap(entity.getDeviceCodeMetadata())));
+        }
+
+        return builder.build();
+    }
+
+    private CustomAuthorization toEntity(OAuth2Authorization authorization) {
+        CustomAuthorization entity = new CustomAuthorization();
+        entity.setId(authorization.getId());
+        entity.setRegisteredClientId(authorization.getRegisteredClientId());
+        entity.setPrincipalName(authorization.getPrincipalName());
+        entity.setAuthorizationGrantType(authorization.getAuthorizationGrantType().getValue());
+        entity.setAuthorizedScopes(StringUtils.collectionToDelimitedString(authorization.getAuthorizedScopes(), ","));
+        entity.setAttributes(writeMap(authorization.getAttributes()));
+        entity.setState(authorization.getAttribute(OAuth2ParameterNames.STATE));
+
+        OAuth2Authorization.Token<OAuth2AuthorizationCode> authorizationCode =
+                authorization.getToken(OAuth2AuthorizationCode.class);
+        setTokenValues(
+                authorizationCode,
+                entity::setAuthorizationCodeValue,
+                entity::setAuthorizationCodeIssuedAt,
+                entity::setAuthorizationCodeExpiresAt,
+                entity::setAuthorizationCodeMetadata
+        );
+
+        OAuth2Authorization.Token<OAuth2AccessToken> accessToken =
+                authorization.getToken(OAuth2AccessToken.class);
+        setTokenValues(
+                accessToken,
+                entity::setAccessTokenValue,
+                entity::setAccessTokenIssuedAt,
+                entity::setAccessTokenExpiresAt,
+                entity::setAccessTokenMetadata
+        );
+        if (accessToken != null && accessToken.getToken().getScopes() != null) {
+            entity.setAccessTokenScopes(StringUtils.collectionToDelimitedString(accessToken.getToken().getScopes(), ","));
+        }
+
+        OAuth2Authorization.Token<OAuth2RefreshToken> refreshToken =
+                authorization.getToken(OAuth2RefreshToken.class);
+        setTokenValues(
+                refreshToken,
+                entity::setRefreshTokenValue,
+                entity::setRefreshTokenIssuedAt,
+                entity::setRefreshTokenExpiresAt,
+                entity::setRefreshTokenMetadata
+        );
+
+        OAuth2Authorization.Token<OidcIdToken> oidcIdToken =
+                authorization.getToken(OidcIdToken.class);
+        setTokenValues(
+                oidcIdToken,
+                entity::setOidcIdTokenValue,
+                entity::setOidcIdTokenIssuedAt,
+                entity::setOidcIdTokenExpiresAt,
+                entity::setOidcIdTokenMetadata
+        );
+        if (oidcIdToken != null) {
+            entity.setOidcIdTokenClaims(writeMap(oidcIdToken.getClaims()));
+        }
+
+        OAuth2Authorization.Token<OAuth2UserCode> userCode =
+                authorization.getToken(OAuth2UserCode.class);
+        setTokenValues(
+                userCode,
+                entity::setUserCodeValue,
+                entity::setUserCodeIssuedAt,
+                entity::setUserCodeExpiresAt,
+                entity::setUserCodeMetadata
+        );
+
+        OAuth2Authorization.Token<OAuth2DeviceCode> deviceCode =
+                authorization.getToken(OAuth2DeviceCode.class);
+        setTokenValues(
+                deviceCode,
+                entity::setDeviceCodeValue,
+                entity::setDeviceCodeIssuedAt,
+                entity::setDeviceCodeExpiresAt,
+                entity::setDeviceCodeMetadata
+        );
+
+        return entity;
+    }
+
+    private void setTokenValues(
+            OAuth2Authorization.Token<?> token,
+            Consumer<String> tokenValueConsumer,
+            Consumer<Instant> issuedAtConsumer,
+            Consumer<Instant> expiresAtConsumer,
+            Consumer<String> metadataConsumer) {
+        if (token != null) {
+            OAuth2Token oAuth2Token = token.getToken();
+            tokenValueConsumer.accept(oAuth2Token.getTokenValue());
+            issuedAtConsumer.accept(oAuth2Token.getIssuedAt());
+            expiresAtConsumer.accept(oAuth2Token.getExpiresAt());
+            metadataConsumer.accept(writeMap(token.getMetadata()));
+        }
+    }
+
+    private Map<String, Object> parseMap(String data) {
+        try {
+            return this.objectMapper.readValue(data, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex.getMessage(), ex);
+        }
+    }
+
+    private String writeMap(Map<String, Object> metadata) {
+        try {
+            return this.objectMapper.writeValueAsString(metadata);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex.getMessage(), ex);
+        }
+    }
+
+    private static AuthorizationGrantType resolveAuthorizationGrantType(String authorizationGrantType) {
+        if (AuthorizationGrantType.AUTHORIZATION_CODE.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.AUTHORIZATION_CODE;
+        } else if (AuthorizationGrantType.CLIENT_CREDENTIALS.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.CLIENT_CREDENTIALS;
+        } else if (AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.REFRESH_TOKEN;
+        } else if (AuthorizationGrantType.DEVICE_CODE.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.DEVICE_CODE;
+        }
+        return new AuthorizationGrantType(authorizationGrantType);              // Custom authorization grant type
+    }
+}
+

--- a/src/main/java/com/si/authserver/core/client/JpaRegisteredClientRepository.java
+++ b/src/main/java/com/si/authserver/core/client/JpaRegisteredClientRepository.java
@@ -1,0 +1,160 @@
+package com.si.authserver.core.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.si.authserver.data.CustomClient;
+import com.si.authserver.infra.mysql.ClientRepository;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JpaRegisteredClientRepository implements RegisteredClientRepository {
+    private final ClientRepository clientRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JpaRegisteredClientRepository(ClientRepository clientRepository) {
+        Assert.notNull(clientRepository, "clientRepository cannot be null");
+        this.clientRepository = clientRepository;
+
+        ClassLoader classLoader = JpaRegisteredClientRepository.class.getClassLoader();
+        List<Module> securityModules = SecurityJackson2Modules.getModules(classLoader);
+        this.objectMapper.registerModules(securityModules);
+        this.objectMapper.registerModule(new OAuth2AuthorizationServerJackson2Module());
+    }
+
+    @Override
+    public void save(RegisteredClient registeredClient) {
+        Assert.notNull(registeredClient, "registeredClient cannot be null");
+        this.clientRepository.save(toEntity(registeredClient));
+    }
+
+    @Override
+    public RegisteredClient findById(String id) {
+        Assert.hasText(id, "id cannot be empty");
+        return this.clientRepository.findById(id).map(this::toObject).orElse(null);
+    }
+
+    @Override
+    public RegisteredClient findByClientId(String clientId) {
+        Assert.hasText(clientId, "clientId cannot be empty");
+        return this.clientRepository.findByClientId(clientId).map(this::toObject).orElse(null);
+    }
+
+    private RegisteredClient toObject(CustomClient client) {
+        Set<String> clientAuthenticationMethods = StringUtils.commaDelimitedListToSet(
+                client.getClientAuthenticationMethods());
+        Set<String> authorizationGrantTypes = StringUtils.commaDelimitedListToSet(
+                client.getAuthorizationGrantTypes());
+        Set<String> redirectUris = StringUtils.commaDelimitedListToSet(
+                client.getRedirectUris());
+        Set<String> postLogoutRedirectUris = StringUtils.commaDelimitedListToSet(
+                client.getPostLogoutRedirectUris());
+        Set<String> clientScopes = StringUtils.commaDelimitedListToSet(
+                client.getScopes());
+
+        RegisteredClient.Builder builder = RegisteredClient.withId(client.getId())
+                .clientId(client.getClientId())
+                .clientIdIssuedAt(client.getClientIdIssuedAt())
+                .clientSecret(client.getClientSecret())
+                .clientSecretExpiresAt(client.getClientSecretExpiresAt())
+                .clientName(client.getClientName())
+                .clientAuthenticationMethods(authenticationMethods ->
+                        clientAuthenticationMethods.forEach(authenticationMethod ->
+                                authenticationMethods.add(resolveClientAuthenticationMethod(authenticationMethod))))
+                .authorizationGrantTypes((grantTypes) ->
+                        authorizationGrantTypes.forEach(grantType ->
+                                grantTypes.add(resolveAuthorizationGrantType(grantType))))
+                .redirectUris((uris) -> uris.addAll(redirectUris))
+                .postLogoutRedirectUris((uris) -> uris.addAll(postLogoutRedirectUris))
+                .scopes((scopes) -> scopes.addAll(clientScopes));
+
+        Map<String, Object> clientSettingsMap = parseMap(client.getClientSettings());
+        builder.clientSettings(ClientSettings.withSettings(clientSettingsMap).build());
+
+        Map<String, Object> tokenSettingsMap = parseMap(client.getTokenSettings());
+        builder.tokenSettings(TokenSettings.withSettings(tokenSettingsMap).build());
+
+        return builder.build();
+    }
+
+    private CustomClient toEntity(RegisteredClient registeredClient) {
+        List<String> clientAuthenticationMethods = new ArrayList<>(registeredClient.getClientAuthenticationMethods().size());
+        registeredClient.getClientAuthenticationMethods().forEach(clientAuthenticationMethod ->
+                clientAuthenticationMethods.add(clientAuthenticationMethod.getValue()));
+
+        List<String> authorizationGrantTypes = new ArrayList<>(registeredClient.getAuthorizationGrantTypes().size());
+        registeredClient.getAuthorizationGrantTypes().forEach(authorizationGrantType ->
+                authorizationGrantTypes.add(authorizationGrantType.getValue()));
+
+        return CustomClient.builder()
+                .clientId(registeredClient.getClientId())
+                .clientIdIssuedAt(registeredClient.getClientIdIssuedAt())
+                .clientSecret(registeredClient.getClientSecret())
+                .clientSecretExpiresAt(registeredClient.getClientSecretExpiresAt())
+                .clientName(registeredClient.getClientName())
+                .clientAuthenticationMethods(StringUtils.collectionToCommaDelimitedString(clientAuthenticationMethods))
+                .authorizationGrantTypes(StringUtils.collectionToCommaDelimitedString(authorizationGrantTypes))
+                .redirectUris(StringUtils.collectionToCommaDelimitedString(registeredClient.getRedirectUris()))
+                .postLogoutRedirectUris(StringUtils.collectionToCommaDelimitedString(registeredClient.getPostLogoutRedirectUris()))
+                .scopes(StringUtils.collectionToCommaDelimitedString(registeredClient.getScopes()))
+                .clientSettings(writeMap(registeredClient.getClientSettings().getSettings()))
+                .tokenSettings(writeMap(registeredClient.getTokenSettings().getSettings()))
+                .build();
+    }
+
+    private Map<String, Object> parseMap(String data) {
+        try {
+            return this.objectMapper.readValue(data, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex.getMessage(), ex);
+        }
+    }
+
+    private String writeMap(Map<String, Object> data) {
+        try {
+            return this.objectMapper.writeValueAsString(data);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex.getMessage(), ex);
+        }
+    }
+
+    private static AuthorizationGrantType resolveAuthorizationGrantType(String authorizationGrantType) {
+        if (AuthorizationGrantType.AUTHORIZATION_CODE.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.AUTHORIZATION_CODE;
+        } else if (AuthorizationGrantType.CLIENT_CREDENTIALS.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.CLIENT_CREDENTIALS;
+        } else if (AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.REFRESH_TOKEN;
+        }
+        return new AuthorizationGrantType(authorizationGrantType);              // Custom authorization grant type
+    }
+
+    private static ClientAuthenticationMethod resolveClientAuthenticationMethod(String clientAuthenticationMethod) {
+        if (ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue().equals(clientAuthenticationMethod)) {
+            return ClientAuthenticationMethod.CLIENT_SECRET_BASIC;
+        } else if (ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue().equals(clientAuthenticationMethod)) {
+            return ClientAuthenticationMethod.CLIENT_SECRET_POST;
+        } else if (ClientAuthenticationMethod.NONE.getValue().equals(clientAuthenticationMethod)) {
+            return ClientAuthenticationMethod.NONE;
+        }
+        return new ClientAuthenticationMethod(clientAuthenticationMethod);      // Custom client authentication method
+    }
+}
+

--- a/src/main/java/com/si/authserver/core/consent/JpaOAuth2AuthorizationConsentService.java
+++ b/src/main/java/com/si/authserver/core/consent/JpaOAuth2AuthorizationConsentService.java
@@ -1,0 +1,86 @@
+package com.si.authserver.core.consent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.si.authserver.data.CustomAuthorizationConsent;
+import com.si.authserver.infra.mysql.AuthorizationConsentRepository;
+
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JpaOAuth2AuthorizationConsentService implements OAuth2AuthorizationConsentService {
+    private final AuthorizationConsentRepository authorizationConsentRepository;
+    private final RegisteredClientRepository registeredClientRepository;
+
+    public JpaOAuth2AuthorizationConsentService(AuthorizationConsentRepository authorizationConsentRepository, RegisteredClientRepository registeredClientRepository) {
+        Assert.notNull(authorizationConsentRepository, "authorizationConsentRepository cannot be null");
+        Assert.notNull(registeredClientRepository, "registeredClientRepository cannot be null");
+        this.authorizationConsentRepository = authorizationConsentRepository;
+        this.registeredClientRepository = registeredClientRepository;
+    }
+
+    @Override
+    public void save(OAuth2AuthorizationConsent authorizationConsent) {
+        Assert.notNull(authorizationConsent, "authorizationConsent cannot be null");
+        this.authorizationConsentRepository.save(toEntity(authorizationConsent));
+    }
+
+    @Override
+    public void remove(OAuth2AuthorizationConsent authorizationConsent) {
+        Assert.notNull(authorizationConsent, "authorizationConsent cannot be null");
+        this.authorizationConsentRepository.deleteByRegisteredClientIdAndPrincipalName(
+                authorizationConsent.getRegisteredClientId(), authorizationConsent.getPrincipalName());
+    }
+
+    @Override
+    public OAuth2AuthorizationConsent findById(String registeredClientId, String principalName) {
+        Assert.hasText(registeredClientId, "registeredClientId cannot be empty");
+        Assert.hasText(principalName, "principalName cannot be empty");
+        return this.authorizationConsentRepository.findByRegisteredClientIdAndPrincipalName(
+                registeredClientId, principalName).map(this::toObject).orElse(null);
+    }
+
+    private OAuth2AuthorizationConsent toObject(CustomAuthorizationConsent authorizationConsent) {
+        String registeredClientId = authorizationConsent.getRegisteredClientId();
+        RegisteredClient registeredClient = this.registeredClientRepository.findById(registeredClientId);
+        if (registeredClient == null) {
+            throw new DataRetrievalFailureException(
+                    "The RegisteredClient with id '" + registeredClientId + "' was not found in the RegisteredClientRepository.");
+        }
+
+        OAuth2AuthorizationConsent.Builder builder = OAuth2AuthorizationConsent.withId(
+                registeredClientId, authorizationConsent.getPrincipalName());
+        if (authorizationConsent.getAuthorities() != null) {
+            for (String authority : StringUtils.commaDelimitedListToSet(authorizationConsent.getAuthorities())) {
+                builder.authority(new SimpleGrantedAuthority(authority));
+            }
+        }
+
+        return builder.build();
+    }
+
+    private CustomAuthorizationConsent toEntity(OAuth2AuthorizationConsent authorizationConsent) {
+        var authConsentBuilder = CustomAuthorizationConsent.builder()
+                        .registeredClientId(authorizationConsent.getRegisteredClientId())
+                                .principalName(authorizationConsent.getPrincipalName());
+
+        Set<String> authorities = new HashSet<>();
+        for (GrantedAuthority authority : authorizationConsent.getAuthorities()) {
+            authorities.add(authority.getAuthority());
+        }
+        authConsentBuilder.authorities(StringUtils.collectionToCommaDelimitedString(authorities));
+
+        return authConsentBuilder.build();
+    }
+}
+

--- a/src/main/java/com/si/authserver/data/CustomAuthorization.java
+++ b/src/main/java/com/si/authserver/data/CustomAuthorization.java
@@ -1,0 +1,116 @@
+package com.si.authserver.data;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "`authorization`")
+public class CustomAuthorization {
+
+    @Id
+    @Column(name = "id")
+    private String id;
+
+    @Column(name = "registered_client_id")
+    private String registeredClientId;
+
+    @Column(name = "principal_name")
+    private String principalName;
+
+    @Column(name = "authorization_grant_type")
+    private String authorizationGrantType;
+
+    @Column(name = "authorized_scopes", length = 1000)
+    private String authorizedScopes;
+
+    @Column(name = "attributes", length = 4000)
+    private String attributes;
+
+    @Column(name = "state", length = 500)
+    private String state;
+
+    @Column(name = "authorization_code_value", length = 4000)
+    private String authorizationCodeValue;
+
+    @Column(name = "authorization_code_issued_at")
+    private Instant authorizationCodeIssuedAt;
+
+    @Column(name = "authorization_code_expires_at")
+    private Instant authorizationCodeExpiresAt;
+
+    @Column(name = "authorization_code_metadata", length = 4000)
+    private String authorizationCodeMetadata;
+
+    @Column(name = "access_token_value", length = 4000)
+    private String accessTokenValue;
+
+    @Column(name = "access_token_issued_at")
+    private Instant accessTokenIssuedAt;
+
+    @Column(name = "access_token_expires_at")
+    private Instant accessTokenExpiresAt;
+
+    @Column(name = "access_token_metadata", length = 2000)
+    private String accessTokenMetadata;
+
+    @Column(name = "access_token_type")
+    private String accessTokenType;
+
+    @Column(name = "access_token_scopes", length = 1000)
+    private String accessTokenScopes;
+
+    @Column(name = "refresh_token_value", length = 4000)
+    private String refreshTokenValue;
+
+    @Column(name = "refresh_token_issued_at")
+    private Instant refreshTokenIssuedAt;
+
+    @Column(name = "refresh_token_expires_at")
+    private Instant refreshTokenExpiresAt;
+
+    @Column(name = "refresh_token_metadata", length = 2000)
+    private String refreshTokenMetadata;
+
+    @Column(name = "oidc_id_token_value", length = 4000)
+    private String oidcIdTokenValue;
+
+    @Column(name = "oidc_id_token_issued_at")
+    private Instant oidcIdTokenIssuedAt;
+
+    @Column(name = "oidc_id_token_expires_at")
+    private Instant oidcIdTokenExpiresAt;
+
+    @Column(name = "oidc_id_token_metadata", length = 2000)
+    private String oidcIdTokenMetadata;
+
+    @Column(name = "oidc_id_token_claims", length = 2000)
+    private String oidcIdTokenClaims;
+
+    @Column(name = "user_code_value", length = 4000)
+    private String userCodeValue;
+
+    @Column(name = "user_code_issued_at")
+    private Instant userCodeIssuedAt;
+
+    @Column(name = "user_code_expires_at")
+    private Instant userCodeExpiresAt;
+
+    @Column(name = "user_code_metadata", length = 2000)
+    private String userCodeMetadata;
+
+    @Column(name = "device_code_value", length = 4000)
+    private String deviceCodeValue;
+
+    @Column(name = "device_code_issued_at")
+    private Instant deviceCodeIssuedAt;
+
+    @Column(name = "device_code_expires_at")
+    private Instant deviceCodeExpiresAt;
+
+    @Column(name = "device_code_metadata", length = 2000)
+    private String deviceCodeMetadata;
+}

--- a/src/main/java/com/si/authserver/data/CustomAuthorization.java
+++ b/src/main/java/com/si/authserver/data/CustomAuthorization.java
@@ -2,17 +2,21 @@ package com.si.authserver.data;
 
 import java.time.Instant;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "`authorization`")
+@Getter
+@Setter
+@NoArgsConstructor
 public class CustomAuthorization {
 
     @Id
     @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
     @Column(name = "registered_client_id")

--- a/src/main/java/com/si/authserver/data/CustomAuthorizationConsent.java
+++ b/src/main/java/com/si/authserver/data/CustomAuthorizationConsent.java
@@ -1,0 +1,44 @@
+package com.si.authserver.data;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "`authorization_consent`")
+@IdClass(CustomAuthorizationConsent.AuthorizationConsentId.class)
+public class CustomAuthorizationConsent {
+    @Id
+    @Column(name = "registered_client_id")
+    private String registeredClientId;
+
+    @Id
+    @Column(name = "principal_name")
+    private String principalName;
+
+    @Column(name = "authorities", length = 1000)
+    private String authorities;
+
+    public static class AuthorizationConsentId implements Serializable {
+        private String registeredClientId;
+        private String principalName;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AuthorizationConsentId that = (AuthorizationConsentId) o;
+            return registeredClientId.equals(that.registeredClientId) && principalName.equals(that.principalName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(registeredClientId, principalName);
+        }
+    }
+}

--- a/src/main/java/com/si/authserver/data/CustomAuthorizationConsent.java
+++ b/src/main/java/com/si/authserver/data/CustomAuthorizationConsent.java
@@ -8,11 +8,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "`authorization_consent`")
 @IdClass(CustomAuthorizationConsent.AuthorizationConsentId.class)
+@Getter
+@NoArgsConstructor
 public class CustomAuthorizationConsent {
+
     @Id
     @Column(name = "registered_client_id")
     private String registeredClientId;
@@ -23,6 +29,13 @@ public class CustomAuthorizationConsent {
 
     @Column(name = "authorities", length = 1000)
     private String authorities;
+
+    @Builder
+    public CustomAuthorizationConsent(String registeredClientId, String principalName, String authorities) {
+        this.registeredClientId = registeredClientId;
+        this.principalName = principalName;
+        this.authorities = authorities;
+    }
 
     public static class AuthorizationConsentId implements Serializable {
         private String registeredClientId;

--- a/src/main/java/com/si/authserver/data/CustomClient.java
+++ b/src/main/java/com/si/authserver/data/CustomClient.java
@@ -1,0 +1,51 @@
+package com.si.authserver.data;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "`client`")
+public class CustomClient {
+    @Id
+    private String id;
+
+    @Column(name = "client_id")
+    private String clientId;
+
+    @Column(name = "client_id_issued_at")
+    private Instant clientIdIssuedAt;
+
+    @Column(name = "client_secret")
+    private String clientSecret;
+
+    @Column(name = "client_secret_expires_at")
+    private Instant clientSecretExpiresAt;
+
+    @Column(name = "client_name")
+    private String clientName;
+
+    @Column(name = "client_authentication_methods", length = 1000)
+    private String clientAuthenticationMethods;
+
+    @Column(name = "authorization_grant_types", length = 1000)
+    private String authorizationGrantTypes;
+
+    @Column(name = "redirect_uris", length = 1000)
+    private String redirectUris;
+
+    @Column(name = "post_logout_redirect_uris", length = 1000)
+    private String postLogoutRedirectUris;
+
+    @Column(name = "scopes", length = 1000)
+    private String scopes;
+
+    @Column(name = "client_settings", length = 2000)
+    private String clientSettings;
+
+    @Column(name = "token_settings", length = 2000)
+    private String tokenSettings;
+}

--- a/src/main/java/com/si/authserver/data/CustomClient.java
+++ b/src/main/java/com/si/authserver/data/CustomClient.java
@@ -1,16 +1,21 @@
 package com.si.authserver.data;
 
-import java.time.Instant;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import java.time.Instant;
 
 @Entity
 @Table(name = "`client`")
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode
 public class CustomClient {
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
     @Column(name = "client_id")
@@ -48,4 +53,20 @@ public class CustomClient {
 
     @Column(name = "token_settings", length = 2000)
     private String tokenSettings;
+
+    @Builder
+    public CustomClient(String clientId, Instant clientIdIssuedAt, String clientSecret, Instant clientSecretExpiresAt, String clientName, String clientAuthenticationMethods, String authorizationGrantTypes, String redirectUris, String postLogoutRedirectUris, String scopes, String clientSettings, String tokenSettings) {
+        this.clientId = clientId;
+        this.clientIdIssuedAt = clientIdIssuedAt;
+        this.clientSecret = clientSecret;
+        this.clientSecretExpiresAt = clientSecretExpiresAt;
+        this.clientName = clientName;
+        this.clientAuthenticationMethods = clientAuthenticationMethods;
+        this.authorizationGrantTypes = authorizationGrantTypes;
+        this.redirectUris = redirectUris;
+        this.postLogoutRedirectUris = postLogoutRedirectUris;
+        this.scopes = scopes;
+        this.clientSettings = clientSettings;
+        this.tokenSettings = tokenSettings;
+    }
 }

--- a/src/main/java/com/si/authserver/infra/mysql/AuthorizationConsentRepository.java
+++ b/src/main/java/com/si/authserver/infra/mysql/AuthorizationConsentRepository.java
@@ -4,6 +4,10 @@ import com.si.authserver.data.CustomAuthorizationConsent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AuthorizationConsentRepository extends JpaRepository<CustomAuthorizationConsent, CustomAuthorizationConsent.AuthorizationConsentId> {
+    Optional<CustomAuthorizationConsent> findByRegisteredClientIdAndPrincipalName(String registeredClientId, String principalName);
+    void deleteByRegisteredClientIdAndPrincipalName(String registeredClientId, String principalName);
 }

--- a/src/main/java/com/si/authserver/infra/mysql/AuthorizationConsentRepository.java
+++ b/src/main/java/com/si/authserver/infra/mysql/AuthorizationConsentRepository.java
@@ -1,0 +1,9 @@
+package com.si.authserver.infra.mysql;
+
+import com.si.authserver.data.CustomAuthorizationConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuthorizationConsentRepository extends JpaRepository<CustomAuthorizationConsent, CustomAuthorizationConsent.AuthorizationConsentId> {
+}

--- a/src/main/java/com/si/authserver/infra/mysql/AuthorizationRepository.java
+++ b/src/main/java/com/si/authserver/infra/mysql/AuthorizationRepository.java
@@ -2,8 +2,35 @@ package com.si.authserver.infra.mysql;
 
 import com.si.authserver.data.CustomAuthorization;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface AuthorizationRepository extends JpaRepository<CustomAuthorization, String> {
+    Optional<CustomAuthorization> findByState(String state);
+
+    Optional<CustomAuthorization> findByAuthorizationCodeValue(String authorizationCode);
+
+    Optional<CustomAuthorization> findByAccessTokenValue(String accessToken);
+
+    Optional<CustomAuthorization> findByRefreshTokenValue(String refreshToken);
+
+    Optional<CustomAuthorization> findByOidcIdTokenValue(String idToken);
+
+    Optional<CustomAuthorization> findByUserCodeValue(String userCode);
+
+    Optional<CustomAuthorization> findByDeviceCodeValue(String deviceCode);
+
+    @Query("select a from CustomAuthorization a where a.state = :token" +
+            " or a.authorizationCodeValue = :token" +
+            " or a.accessTokenValue = :token" +
+            " or a.refreshTokenValue = :token" +
+            " or a.oidcIdTokenValue = :token" +
+            " or a.userCodeValue = :token" +
+            " or a.deviceCodeValue = :token"
+    )
+    Optional<CustomAuthorization> findByStateOrAuthorizationCodeValueOrAccessTokenValueOrRefreshTokenValueOrOidcIdTokenValueOrUserCodeValueOrDeviceCodeValue(@Param("token") String token);
 }

--- a/src/main/java/com/si/authserver/infra/mysql/AuthorizationRepository.java
+++ b/src/main/java/com/si/authserver/infra/mysql/AuthorizationRepository.java
@@ -1,0 +1,9 @@
+package com.si.authserver.infra.mysql;
+
+import com.si.authserver.data.CustomAuthorization;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuthorizationRepository extends JpaRepository<CustomAuthorization, String> {
+}

--- a/src/main/java/com/si/authserver/infra/mysql/ClientRepository.java
+++ b/src/main/java/com/si/authserver/infra/mysql/ClientRepository.java
@@ -1,0 +1,10 @@
+package com.si.authserver.infra.mysql;
+
+import com.si.authserver.data.CustomClient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClientRepository extends JpaRepository<CustomClient, String> {
+
+}

--- a/src/main/java/com/si/authserver/infra/mysql/ClientRepository.java
+++ b/src/main/java/com/si/authserver/infra/mysql/ClientRepository.java
@@ -4,7 +4,9 @@ import com.si.authserver.data.CustomClient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ClientRepository extends JpaRepository<CustomClient, String> {
-
+    Optional<CustomClient> findByClientId(String clientId);
 }

--- a/src/main/resources/schema/data.sql
+++ b/src/main/resources/schema/data.sql
@@ -1,0 +1,64 @@
+-- Description: SQL script to create the tables and insert the data for the OAuth 2.0 Authorization Server.
+-- https://docs.spring.io/spring-authorization-server/docs/current/reference/html/guides/how-to-jpa.html
+
+CREATE TABLE IF NOT EXISTS client (
+    id varchar(255) NOT NULL,
+    client_id varchar(255) NOT NULL,
+    client_id_issued_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret varchar(255) DEFAULT NULL,
+    client_secret_expires_at timestamp DEFAULT NULL,
+    client_name varchar(255) NOT NULL,
+    client_authentication_methods varchar(1000) NOT NULL,
+    authorization_grant_types varchar(1000) NOT NULL,
+    redirect_uris varchar(1000) DEFAULT NULL,
+    post_logout_redirect_uris varchar(1000) DEFAULT NULL,
+    scopes varchar(1000) NOT NULL,
+    client_settings varchar(2000) NOT NULL,
+    token_settings varchar(2000) NOT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS authorization (
+    id varchar(255) NOT NULL,
+    registered_client_id varchar(255) NOT NULL,
+    principal_name varchar(255) NOT NULL,
+    authorization_grant_type varchar(255) NOT NULL,
+    authorized_scopes varchar(1000) DEFAULT NULL,
+    attributes TEXT DEFAULT NULL,
+    state TEXT DEFAULT NULL,
+    authorization_code_value TEXT DEFAULT NULL,
+    authorization_code_issued_at timestamp DEFAULT NULL,
+    authorization_code_expires_at timestamp DEFAULT NULL,
+    authorization_code_metadata TEXT DEFAULT NULL,
+    access_token_value TEXT DEFAULT NULL,
+    access_token_issued_at timestamp DEFAULT NULL,
+    access_token_expires_at timestamp DEFAULT NULL,
+    access_token_metadata TEXT DEFAULT NULL,
+    access_token_type varchar(255) DEFAULT NULL,
+    access_token_scopes varchar(1000) DEFAULT NULL,
+    refresh_token_value TEXT DEFAULT NULL,
+    refresh_token_issued_at timestamp DEFAULT NULL,
+    refresh_token_expires_at timestamp DEFAULT NULL,
+    refresh_token_metadata TEXT DEFAULT NULL,
+    oidc_id_token_value TEXT DEFAULT NULL,
+    oidc_id_token_issued_at timestamp DEFAULT NULL,
+    oidc_id_token_expires_at timestamp DEFAULT NULL,
+    oidc_id_token_metadata TEXT DEFAULT NULL,
+    oidc_id_token_claims TEXT DEFAULT NULL,
+    user_code_value TEXT DEFAULT NULL,
+    user_code_issued_at timestamp DEFAULT NULL,
+    user_code_expires_at timestamp DEFAULT NULL,
+    user_code_metadata TEXT DEFAULT NULL,
+    device_code_value TEXT DEFAULT NULL,
+    device_code_issued_at timestamp DEFAULT NULL,
+    device_code_expires_at timestamp DEFAULT NULL,
+    device_code_metadata TEXT DEFAULT NULL,
+    PRIMARY KEY (id)
+    );
+
+CREATE TABLE IF NOT EXISTS authorization_consent (
+    registered_client_id varchar(255) NOT NULL,
+    principal_name varchar(255) NOT NULL,
+    authorities varchar(1000) NOT NULL,
+    PRIMARY KEY (registered_client_id, principal_name)
+);


### PR DESCRIPTION
📝  작업 사항

- Spring Authorization Server의 Core Service를 Spring Data JPA로 구현
- RegisteredClient : 인증/인가를 위한 클라이언트 메타데이터 정보 디비 저장 
- OAuth2Authorization : 인증/인가 완료 후 해당 인가에 대한 메타데이터 정보 디비 저장
- OAuth2AuthorizationConsent  : 사용자 동의 후 해당 정보(클라이언트-사용자) 디비 저장